### PR TITLE
Update step-by-step-walkthrough.md

### DIFF
--- a/docs/docs/step-by-step-walkthrough.md
+++ b/docs/docs/step-by-step-walkthrough.md
@@ -197,3 +197,4 @@ The following script will check environment variables, deploy the infrastructure
 [doctl]: https://www.digitalocean.com/docs/apis-clis/doctl/how-to/install/
 [oauth application]: https://docs.github.com/en/free-pro-team@latest/developers/apps/authorizing-oauth-apps
 [recording your DNS]: https://support.cloudflare.com/hc/en-us/articles/360019093151-Managing-DNS-records-in-Cloudflare
+


### PR DESCRIPTION
Here are some proposed changes. Foremost I thought the "scripts" reference was not necessary since config and deployment is handled nicely with "qhub render" and "qhub deploy". Tried to also make it more generic for other DNS services and be a little more prescriptive of how to use AWS vs DO/GCP. And since it's October, and the PR is accepted, I guess there is the Hacktoberfest merit possible...